### PR TITLE
Fix value of clojure-snippets-dir

### DIFF
--- a/clojure-snippets.el
+++ b/clojure-snippets.el
@@ -22,8 +22,7 @@
 
 ;;; Code:
 
-(setq clojure-snippets-dir (file-name-directory (or (buffer-file-name)
-                                                    load-file-name)))
+(setq clojure-snippets-dir (file-name-directory load-file-name))
 
 ;;;###autoload
 (defun clojure-snippets-initialize ()


### PR DESCRIPTION
This package was included in Spacemacs a couple of days ago, but it has caused a bug: https://github.com/syl20bnr/spacemacs/issues/5373

The problem is that when the package loads, the value of `clojure-snippets-dir` takes on the path of the file I'm opening, not the path the actual package is in. This causes some annoying problems as you can see in the bug report.

I don't know why `(buffer-file-name)` comes first but removing it fixes the problem for me.