### PR TITLE
Dependency fix

### DIFF
--- a/clojure-snippets.el
+++ b/clojure-snippets.el
@@ -5,7 +5,7 @@
 ;; Author: Max Penet <m@qbits.cc>
 ;; Keywords: snippets
 ;; Version: 1.0.0
-;; Package-Requires: ((yasnippet "0.8.0"))
+;; Package-Requires: ((yasnippet "0.8.0") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/snippets/clojure-mode/ns
+++ b/snippets/clojure-mode/ns
@@ -2,15 +2,15 @@
 # name: ns
 # key: ns
 # --
-(ns `(flet ((try-src-prefix
+(ns `(cl-flet ((try-src-prefix
 	  (path src-pfx)
 	  (let ((parts (split-string path src-pfx)))
 	    (if (= 2 (length parts))
-		(second parts)
+		(cl-second parts)
 	      nil))))
     (let* ((p (buffer-file-name))
-           (p2 (first
-		(remove-if-not '(lambda (x) x)
+           (p2 (cl-first
+		(cl-remove-if-not '(lambda (x) x)
 			       (mapcar
 				'(lambda (pfx)
 				   (try-src-prefix p pfx))

--- a/snippets/clojure-mode/ns
+++ b/snippets/clojure-mode/ns
@@ -3,20 +3,20 @@
 # key: ns
 # --
 (ns `(cl-flet ((try-src-prefix
-	  (path src-pfx)
-	  (let ((parts (split-string path src-pfx)))
-	    (if (= 2 (length parts))
-		(cl-second parts)
-	      nil))))
-    (let* ((p (buffer-file-name))
-           (p2 (cl-first
-		(cl-remove-if-not '(lambda (x) x)
-			       (mapcar
-				'(lambda (pfx)
-				   (try-src-prefix p pfx))
-				'("/src/cljs/" "/src/clj/" "/src/")))))
-	   (p3 (file-name-sans-extension p2))
-	   (p4 (mapconcat '(lambda (x) x)
-		 (split-string p3 "/")
-		 ".")))
-      (replace-regexp-in-string "_" "-" p4)))`)
+		(path src-pfx)
+		(let ((parts (split-string path src-pfx)))
+		  (if (= 2 (length parts))
+		      (cl-second parts)
+		    nil))))
+       (let* ((p (buffer-file-name))
+	      (p2 (cl-first
+		   (cl-remove-if-not '(lambda (x) x)
+				     (mapcar
+				      '(lambda (pfx)
+					 (try-src-prefix p pfx))
+				      '("/src/cljs/" "/src/clj/" "/src/")))))
+	      (p3 (file-name-sans-extension p2))
+	      (p4 (mapconcat '(lambda (x) x)
+			     (split-string p3 "/")
+			     ".")))
+	 (replace-regexp-in-string "_" "-" p4)))`)


### PR DESCRIPTION
Hey @mpenet 

using the `ns` snippet with Emacs 25.1.1 and the `yasnippet-20160801.1142`, along with `clojure-snippets-20160728.29` from MELPA, I got the following errors:

```clojure
(ns [yas] elisp error: Symbol’s function definition is void: flet)
(ns [yas] elisp error: Symbol’s function definition is void: first)
(ns [yas] elisp error: Symbol’s function definition is void: remove-if-not)
(ns [yas] elisp error: Symbol’s function definition is void: second)
```

The key words there being `flet`, `first`, `remove-if-not` & `second`. Which are all part of `cl-lib` and now have the prefix of `cl-`. See: 	3dcabca

Then I declared `cl-lib` as a dependency in the header, see: 9ced8d9

Let me know what you think of the change.

Thanks