### PR TITLE
Make the 'ns' snippet work for test files

### DIFF
--- a/snippets/clojure-mode/ns
+++ b/snippets/clojure-mode/ns
@@ -14,7 +14,7 @@
 				     (mapcar
 				      '(lambda (pfx)
 					 (try-src-prefix p pfx))
-				      '("/src/cljs/" "/src/clj/" "/src/")))))
+				      '("/src/cljs/" "/src/clj/" "/src/" "/test/")))))
 	      (p3 (file-name-sans-extension p2))
 	      (p4 (mapconcat '(lambda (x) x)
 			     (split-string p3 "/")


### PR DESCRIPTION
I had **clojure-snippets** loaded and all was working well when I went to create a file for test.
Then I started to get this error:

```emacs-lisp
(ns [yas] elisp error: Wrong type argument: stringp, nil )
```

This puzzled me and got me worried that maybe I introduced this bug with my previous PR: https://github.com/mpenet/clojure-snippets/pull/8 

But then I realised that this is a file that is under **test** directory! 😄  

So I added the "/test/" path so that the **ns snippet** works for files that are
created under 'test' directory and not just the files under "/src/*".
