### PR TITLE
fix ns snippet for emacs 28.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.yas-compiled-snippets.el

--- a/snippets/clojure-mode/ns
+++ b/snippets/clojure-mode/ns
@@ -10,13 +10,13 @@
 		    nil))))
        (let* ((p (buffer-file-name))
 	      (p2 (cl-first
-		   (cl-remove-if-not '(lambda (x) x)
+		   (cl-remove-if-not (lambda (x) x)
 				     (mapcar
-				      '(lambda (pfx)
+				      (lambda (pfx)
 					 (try-src-prefix p pfx))
 				      '("/src/cljs/" "/src/clj/" "/src/" "/test/")))))
 	      (p3 (file-name-sans-extension p2))
-	      (p4 (mapconcat '(lambda (x) x)
+	      (p4 (mapconcat (lambda (x) x)
 			     (split-string p3 "/")
 			     ".")))
 	 (replace-regexp-in-string "_" "-" p4)))`)


### PR DESCRIPTION
emacs 28.1 + yasnippet 20200604.246 do not support quoted lambdas, removing the quote fixes the snippet.