### PR TITLE
Update dependency information in library header

### DIFF
--- a/clojure-snippets-pkg.el
+++ b/clojure-snippets-pkg.el
@@ -1,3 +1,0 @@
-(define-package "clojure-snippets" "1.0.1"
-  "Yasnippets for clojure"
-  '((yasnippet "0.10.0")))

--- a/clojure-snippets.el
+++ b/clojure-snippets.el
@@ -5,7 +5,7 @@
 ;; Author: Max Penet <m@qbits.cc>
 ;; Keywords: snippets
 ;; Version: 1.0.1
-;; Package-Requires: ((yasnippet "0.8.0") (cl-lib "0.5"))
+;; Package-Requires: ((yasnippet "0.10.0") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing `<name>-pkg.el` and updating the information in `<name>.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.